### PR TITLE
Inherit wrapped logger names in JBossLoggerAdapter

### DIFF
--- a/src/main/java/org/jboss/slf4j/JBossLoggerAdapter.java
+++ b/src/main/java/org/jboss/slf4j/JBossLoggerAdapter.java
@@ -49,6 +49,7 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
     // package access so that only JBossLoggerFactory be able to create one.
     JBossLoggerAdapter(org.jboss.logging.Logger logger) {
         this.logger = logger;
+        this.name = logger.getName();
     }
 
     @Override


### PR DESCRIPTION
Sets the `name` field of the JBossLoggerAdapter implementation to
whatever the name is on the wrapped logger instance. Previously,
attempting to get the name of a JBoss wrapped logger would always return
`null`.

Fixes #8.