### PR TITLE
Changed to use org.jboss.logmanager instead of org.jboss.logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     </licenses>
 
     <properties>
-        <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.17.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.slf4j>1.7.21</version.org.slf4j>
         <!-- Test dependencies -->
         <version.junit>4.12</version.junit>
@@ -52,11 +52,10 @@
             <artifactId>slf4j-api</artifactId>
             <version>${version.org.slf4j}</version>
         </dependency>
-
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>${version.org.jboss.logging}</version>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <version>${version.org.jboss.logmanager.jboss-logmanager}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/org/jboss/slf4j/JBossLoggerAdapter.java
+++ b/src/main/java/org/jboss/slf4j/JBossLoggerAdapter.java
@@ -17,7 +17,7 @@
  */
 package org.jboss.slf4j;
 
-import org.jboss.logging.Logger.Level;
+import org.jboss.logmanager.ExtLogRecord;
 import org.slf4j.Logger;
 import org.slf4j.Marker;
 import org.slf4j.helpers.FormattingTuple;
@@ -26,7 +26,7 @@ import org.slf4j.helpers.MessageFormatter;
 import org.slf4j.spi.LocationAwareLogger;
 
 /**
- * A wrapper over {@link org.jboss.logging.Logger org.jboss.logging.Logger}
+ * A wrapper over {@link org.jboss.logmanager.Logger org.jboss.logmanager.Logger}
  * in conformance with the {@link Logger} interface.
  * <p/>
  * Adapted from the corresponding slf4j-log4j adapter.
@@ -38,13 +38,13 @@ import org.slf4j.spi.LocationAwareLogger;
 public final class JBossLoggerAdapter extends MarkerIgnoringBase implements LocationAwareLogger {
     private static final long serialVersionUID = -1855332334983449117L;
 
-    final org.jboss.logging.Logger logger;
+    final org.jboss.logmanager.Logger logger;
 
     private static final String LOGGER_FQCN = JBossLoggerAdapter.class.getName();
 
     // package access so that only JBossLoggerFactory be able to create one.
-    JBossLoggerAdapter(org.jboss.logging.Logger logger) {
-        this.logger = logger;
+    JBossLoggerAdapter(org.jboss.logmanager.Logger jbossLogger) {
+        this.logger = jbossLogger;
         this.name = logger.getName();
     }
 
@@ -53,23 +53,23 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
         FormattingTuple result = MessageFormatter.arrayFormat(message, argArray);
         switch (level) {
             case LocationAwareLogger.TRACE_INT:
-                logger.trace(fqcn, result.getMessage(), argArray, t);
+                log(JDKLevel.TRACE, fqcn, result.getMessage(), t, argArray);
                 break;
 
             case LocationAwareLogger.DEBUG_INT:
-                logger.debug(fqcn, result.getMessage(), argArray, t);
+                log(JDKLevel.DEBUG, fqcn, result.getMessage(), t, argArray);
                 break;
 
             case LocationAwareLogger.INFO_INT:
-                logger.info(fqcn, result.getMessage(), argArray, t);
+                log(JDKLevel.INFO, fqcn, result.getMessage(), t, argArray);
                 break;
 
             case LocationAwareLogger.WARN_INT:
-                logger.warn(fqcn, result.getMessage(), argArray, t);
+                log(JDKLevel.WARN, fqcn, result.getMessage(), t, argArray);
                 break;
 
             case LocationAwareLogger.ERROR_INT:
-                logger.error(fqcn, result.getMessage(), argArray, t);
+                log(JDKLevel.ERROR, fqcn, result.getMessage(), t, argArray);
                 break;
 
             default:
@@ -79,140 +79,140 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
 
     @Override
     public boolean isTraceEnabled() {
-        return logger.isTraceEnabled();
+        return logger.isLoggable(JDKLevel.TRACE);
     }
 
     @Override
     public void trace(final String msg) {
-        log(Level.TRACE, LOGGER_FQCN, msg);
+        log(JDKLevel.TRACE, LOGGER_FQCN, msg);
     }
 
     @Override
     public void trace(final String format, final Object arg) {
-        if (logger.isTraceEnabled()) {
+        if (isTraceEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg);
-            log(Level.TRACE, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
+            log(JDKLevel.TRACE, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
         }
     }
 
     @Override
     public void trace(final String format, final Object arg1, final Object arg2) {
-        if (logger.isTraceEnabled()) {
+        if (isTraceEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg1, arg2);
-            log(Level.TRACE, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
+            log(JDKLevel.TRACE, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
         }
     }
 
     @Override
     public void trace(final String format, final Object... arguments) {
-        if (logger.isTraceEnabled()) {
+        if (isTraceEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.arrayFormat(format, arguments);
-            log(Level.TRACE, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
+            log(JDKLevel.TRACE, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
         }
     }
 
     @Override
     public void trace(final String msg, final Throwable t) {
-        if (logger.isTraceEnabled()) {
-            log(Level.TRACE, LOGGER_FQCN, msg, t);
+        if (isTraceEnabled()) {
+            log(JDKLevel.TRACE, LOGGER_FQCN, msg, t);
         }
     }
 
     @Override
     public boolean isDebugEnabled() {
-        return logger.isDebugEnabled();
+        return logger.isLoggable(JDKLevel.DEBUG);
     }
 
     @Override
     public void debug(final String msg) {
-        if (logger.isDebugEnabled()) {
-            log(Level.DEBUG, LOGGER_FQCN, msg);
+        if (isDebugEnabled()) {
+            log(JDKLevel.DEBUG, LOGGER_FQCN, msg);
         }
     }
 
     @Override
     public void debug(final String format, final Object arg) {
-        if (logger.isDebugEnabled()) {
+        if (isDebugEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg);
-            log(Level.DEBUG, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
+            log(JDKLevel.DEBUG, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
         }
     }
 
     @Override
     public void debug(final String format, final Object arg1, final Object arg2) {
-        if (logger.isDebugEnabled()) {
+        if (isDebugEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg1, arg2);
-            log(Level.DEBUG, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
+            log(JDKLevel.DEBUG, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
         }
     }
 
     @Override
     public void debug(final String format, final Object... arguments) {
-        if (logger.isDebugEnabled()) {
+        if (isDebugEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.arrayFormat(format, arguments);
-            log(Level.DEBUG, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
+            log(JDKLevel.DEBUG, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
         }
     }
 
     @Override
     public void debug(final String msg, final Throwable t) {
-        if (logger.isDebugEnabled()) {
-            log(Level.DEBUG, LOGGER_FQCN, msg, t);
+        if (isDebugEnabled()) {
+            log(JDKLevel.DEBUG, LOGGER_FQCN, msg, t);
         }
     }
 
     @Override
     public boolean isInfoEnabled() {
-        return logger.isInfoEnabled();
+        return logger.isLoggable(JDKLevel.INFO);
     }
 
     @Override
     public void info(final String msg) {
-        if (logger.isInfoEnabled()) {
-            log(Level.INFO, LOGGER_FQCN, msg);
+        if (isInfoEnabled()) {
+            log(JDKLevel.INFO, LOGGER_FQCN, msg);
         }
     }
 
     @Override
     public void info(final String format, final Object arg) {
-        if (logger.isInfoEnabled()) {
+        if (isInfoEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg);
-            log(Level.INFO, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
+            log(JDKLevel.INFO, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
         }
     }
 
     @Override
     public void info(final String format, final Object arg1, final Object arg2) {
-        if (logger.isInfoEnabled()) {
+        if (isInfoEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg1, arg2);
-            log(Level.INFO, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
+            log(JDKLevel.INFO, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
         }
     }
 
     @Override
     public void info(final String format, final Object... arguments) {
-        if (logger.isInfoEnabled()) {
+        if (isInfoEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.arrayFormat(format, arguments);
-            log(Level.INFO, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
+            log(JDKLevel.INFO, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
         }
     }
 
     @Override
     public void info(final String msg, final Throwable t) {
-        if (logger.isInfoEnabled()) {
-            log(Level.INFO, LOGGER_FQCN, msg, t);
+        if (isInfoEnabled()) {
+            log(JDKLevel.INFO, LOGGER_FQCN, msg, t);
         }
     }
 
     @Override
     public boolean isWarnEnabled() {
-        return logger.isEnabled(Level.WARN);
+        return logger.isLoggable(JDKLevel.WARN);
     }
 
     @Override
     public void warn(final String msg) {
         if (isWarnEnabled()) {
-            log(Level.WARN, LOGGER_FQCN, msg);
+            log(JDKLevel.WARN, LOGGER_FQCN, msg);
         }
     }
 
@@ -220,7 +220,7 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
     public void warn(final String format, final Object arg) {
         if (isWarnEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg);
-            log(Level.WARN, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
+            log(JDKLevel.WARN, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
         }
     }
 
@@ -228,7 +228,7 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
     public void warn(final String format, final Object... arguments) {
         if (isWarnEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.arrayFormat(format, arguments);
-            log(Level.WARN, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
+            log(JDKLevel.WARN, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
         }
     }
 
@@ -236,26 +236,26 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
     public void warn(final String format, final Object arg1, final Object arg2) {
         if (isWarnEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg1, arg2);
-            log(Level.WARN, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
+            log(JDKLevel.WARN, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
         }
     }
 
     @Override
     public void warn(final String msg, final Throwable t) {
         if (isWarnEnabled()) {
-            log(Level.WARN, LOGGER_FQCN, msg, t);
+            log(JDKLevel.WARN, LOGGER_FQCN, msg, t);
         }
     }
 
     @Override
     public boolean isErrorEnabled() {
-        return logger.isEnabled(Level.ERROR);
+        return logger.isLoggable(JDKLevel.ERROR);
     }
 
     @Override
     public void error(final String msg) {
         if (isErrorEnabled()) {
-            log(Level.ERROR, LOGGER_FQCN, msg);
+            log(JDKLevel.ERROR, LOGGER_FQCN, msg);
         }
     }
 
@@ -263,7 +263,7 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
     public void error(final String format, final Object arg) {
         if (isErrorEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg);
-            log(Level.ERROR, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
+            log(JDKLevel.ERROR, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg);
         }
     }
 
@@ -271,7 +271,7 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
     public void error(final String format, final Object arg1, final Object arg2) {
         if (isErrorEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.format(format, arg1, arg2);
-            log(Level.ERROR, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
+            log(JDKLevel.ERROR, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arg1, arg2);
         }
     }
 
@@ -279,26 +279,26 @@ public final class JBossLoggerAdapter extends MarkerIgnoringBase implements Loca
     public void error(final String format, final Object... arguments) {
         if (isErrorEnabled()) {
             final FormattingTuple formattingTuple = MessageFormatter.arrayFormat(format, arguments);
-            log(Level.ERROR, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
+            log(JDKLevel.ERROR, LOGGER_FQCN, formattingTuple.getMessage(), formattingTuple.getThrowable(), arguments);
         }
     }
 
     @Override
     public void error(final String msg, final Throwable t) {
         if (isErrorEnabled()) {
-            log(Level.ERROR, LOGGER_FQCN, msg, t);
+            log(JDKLevel.ERROR, LOGGER_FQCN, msg, t);
         }
     }
 
-    private void log(final org.jboss.logging.Logger.Level level, final String fqcn, final Object message) {
+    private void log(final java.util.logging.Level level, final String fqcn, final String message) {
         log(level, fqcn, message, null);
     }
 
-    private void log(final org.jboss.logging.Logger.Level level, final String fqcn, final Object message, final Throwable t) {
-        logger.log(fqcn, level, message, null, t);
+    private void log(final java.util.logging.Level level, final String fqcn, final String message, final Throwable t) {
+        logger.log(fqcn, level, message, t);
     }
 
-    private void log(final org.jboss.logging.Logger.Level level, final String fqcn, final Object message, final Throwable t, Object... args) {
-        logger.log(fqcn, level, message, args, t);
+    private void log(final java.util.logging.Level level, final String fqcn, final String message, final Throwable t, Object... args) {
+        logger.log(fqcn, level, message, ExtLogRecord.FormatStyle.NO_FORMAT, args, t);
     }
 }

--- a/src/main/java/org/jboss/slf4j/JBossLoggerFactory.java
+++ b/src/main/java/org/jboss/slf4j/JBossLoggerFactory.java
@@ -20,26 +20,28 @@ package org.jboss.slf4j;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jboss.logmanager.LogContext;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
 /**
  * JBossLoggerFactory is an implementation of {@link ILoggerFactory} returning
  * the appropriate named {@link JBossLoggerAdapter} instance.
- * 
+ *
  * Adapted from the corresponding slf4j-log4j adapter.
- * 
+ *
  * @author <a href="mailto:dimitris@jboss.org">Dimitris Andreadis</a>
  * @version <tt>$Revision: 2784 $</tt>
  */
 public class JBossLoggerFactory implements ILoggerFactory
 {
    /** JBossLoggerAdapter cache */
-   Map loggerMap;
+   private final Map<String, Logger> loggerMap;
+   private final LogContext logContext;
 
-   public JBossLoggerFactory()
-   {
-      loggerMap = new HashMap();
+   public JBossLoggerFactory() {
+      loggerMap = new HashMap<>();
+      logContext = LogContext.getLogContext();
    }
 
    /**
@@ -47,23 +49,22 @@ public class JBossLoggerFactory implements ILoggerFactory
     */
    public Logger getLogger(String name)
    {
-      Logger slf4jLogger = null;
-    
+      Logger slf4jLogger;
+
       // protect against concurrent access of loggerMap
       synchronized (this)
       {
-         slf4jLogger = (Logger) loggerMap.get(name);
-        
+         slf4jLogger = loggerMap.get(name);
+
          // no logger found
          if (slf4jLogger == null)
          {
             // create a new jboss logger
-            org.jboss.logging.Logger jbossLogger;
-            jbossLogger = org.jboss.logging.Logger.getLogger(name);
-            
+            final org.jboss.logmanager.Logger jbossLogger = logContext.getLogger(name);
+
             // wrap it with an adapter
             slf4jLogger = new JBossLoggerAdapter(jbossLogger);
-        
+
             // put it in the map
             loggerMap.put(name, slf4jLogger);
          }

--- a/src/main/java/org/jboss/slf4j/JBossMDCAdapter.java
+++ b/src/main/java/org/jboss/slf4j/JBossMDCAdapter.java
@@ -19,12 +19,12 @@ package org.jboss.slf4j;
 
 import java.util.Map;
 
-import org.jboss.logging.MDC;
+import org.jboss.logmanager.MDC;
 import org.slf4j.spi.MDCAdapter;
 
 /**
  * Adapted from the corresponding slf4j-log4j adapter.
- * 
+ *
  * @author <a href="mailto:dimitris@jboss.org">Dimitris Andreadis</a>
  * @version <tt>$Revision: 2784 $</tt>
  */
@@ -33,15 +33,12 @@ public class JBossMDCAdapter implements MDCAdapter
 
    public void clear()
    {
-      Map map = MDC.getMap();
-
-      if (map != null)
-         map.clear();
+      MDC.clear();
    }
 
    public String get(String key)
    {
-      return (String) MDC.get(key);
+      return MDC.get(key);
    }
 
    public void put(String key, String val)
@@ -54,15 +51,15 @@ public class JBossMDCAdapter implements MDCAdapter
       MDC.remove(key);
    }
 
-   public Map getCopyOfContextMap()
+   public Map<String, String> getCopyOfContextMap()
    {
-      return MDC.getMap();
+      return MDC.copy();
    }
 
    public void setContextMap(final Map contextMap)
    {
       clear();
-      for (Map.Entry entry : ((Map<?,?>)contextMap).entrySet()) {
+      for (Map.Entry<?,?> entry : ((Map<?,?>)contextMap).entrySet()) {
          final Object key = entry.getKey();
          final Object value = entry.getValue();
          if (key != null) {

--- a/src/main/java/org/jboss/slf4j/JDKLevel.java
+++ b/src/main/java/org/jboss/slf4j/JDKLevel.java
@@ -1,0 +1,19 @@
+package org.jboss.slf4j;
+
+import java.util.logging.Level;
+
+final class JDKLevel extends Level {
+
+    private static final long serialVersionUID = 1L;
+
+    protected JDKLevel(final String name, final int value) {
+        super(name, value);
+    }
+
+    public static final JDKLevel ERROR = new JDKLevel("ERROR", 1000);
+    public static final JDKLevel WARN = new JDKLevel("WARN", 900);
+    @SuppressWarnings("hiding")
+    public static final JDKLevel INFO = new JDKLevel("INFO", 800);
+    public static final JDKLevel DEBUG = new JDKLevel("DEBUG", 500);
+    public static final JDKLevel TRACE = new JDKLevel("TRACE", 400);
+}


### PR DESCRIPTION
Changed to use org.jboss.logmanager instead of org.jboss.logging, to be able to with log with FormatStyle.NO_FORMAT as this is already done with slf4j.